### PR TITLE
Adjusts the admin menu to use a dashicon for visual consistency.

### DIFF
--- a/lib/admin/class-groups-admin.php
+++ b/lib/admin/class-groups-admin.php
@@ -160,9 +160,10 @@ class Groups_Admin {
 			GROUPS_ADMINISTER_GROUPS,
 			'groups-admin',
 			apply_filters( 'groups_add_menu_page_function', 'groups_admin_groups' ),
-			GROUPS_PLUGIN_URL . '/images/groups.png',
+			'dashicons-groups',
 			self::MENU_POSITION
 		);
+
 		$pages[] = $page;
 		add_action( 'admin_print_styles-' . $page, array( __CLASS__, 'admin_print_styles' ) );
 		add_action( 'admin_print_scripts-' . $page, array( __CLASS__, 'admin_print_scripts' ) );


### PR DESCRIPTION
Adjusts the admin menu to use a dashicon for visual consistency. This helps to keep the "Groups" admin menu within the same UI look and feel as the rest of WordPress core.

Before:
![image](https://cloud.githubusercontent.com/assets/880803/11359781/ea1b9342-9287-11e5-9431-51c557b948dd.png)

After:
![image](https://cloud.githubusercontent.com/assets/880803/11359771/cd95cb2a-9287-11e5-8036-a31c3be401bb.png)

This is the first in a series of small UI/UX pull requests I'd like to submit. Would you prefer a single pull request with a bunch of different UI tweaks, or individual pull requests for each one, @itthinx ?