### PR TITLE
Freshen up the main admin UI elements

### DIFF
--- a/css/groups_admin.css
+++ b/css/groups_admin.css
@@ -286,23 +286,23 @@ div.groups-footer form {
 	background-color: #fff;
 	border: 1px solid #ccc;
 }
-.groups-admin-add-ons h3 {
+.groups-admin-add-ons .add-ons h3 {
 	margin: 0;
 	display: block;
 	clear: both;
 }
-.groups-admin-add-ons h3 img {
+.groups-admin-add-ons .add-ons h3 img {
 	vertical-align: middle;
 	margin: 0 8px 0 0;
 	display: block;
 	float: left;
 }
-.groups-admin-add-ons a {
+.groups-admin-add-ons .add-ons a {
 	text-decoration: none;
 	display: block;
 	overflow: hidden;
 }
-.groups-admin-add-ons p {
+.groups-admin-add-ons .add-ons p {
 	margin: 0;
 	padding-top: 8px;
 	clear: both;

--- a/css/groups_admin.css
+++ b/css/groups_admin.css
@@ -1,18 +1,18 @@
 /**
  * groups_admin.css
- * 
+ *
  * Copyright (c) "kento" Karim Rahimpur www.itthinx.com
- * 
+ *
  * This code is released under the GNU General Public License.
  * See COPYRIGHT.txt and LICENSE.txt.
- * 
+ *
  * This code is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * This header and all notices must be kept intact.
- * 
+ *
  * @author Karim Rahimpur
  * @package groups
  * @since groups 1.0.0
@@ -21,12 +21,17 @@
 .manage-capabilities {
 	margin-right: 1em;
 }
-.filters,
-.manage {
-	background-color: #fff;
-	padding: 1em;
+.filters fieldset,
+.manage fieldset {
+	display: inline-block;
+	clear: both;
 	margin-bottom: 1em;
-	border: 1px solid #ddd;
+}
+.filters legend {
+	display: inline;
+	font-weight: bold;
+	font-size: 120%;
+	margin-bottom: 1em;
 }
 .manage a.add {
 	text-decoration: none;
@@ -75,9 +80,6 @@ input.group-name-filter,
 input.capability-id-filter,
 input.capability-filter {
 	margin-right: 1em;
-}
-input[name="clear_filters"] {
-	float:right;
 }
 
 div.group.new label,

--- a/lib/admin/groups-admin-add-ons.php
+++ b/lib/admin/groups-admin-add-ons.php
@@ -1,19 +1,19 @@
 <?php
 /**
  * groups-admin-add-ons.php
- * 
+ *
  * Copyright (c) "kento" Karim Rahimpur www.itthinx.com
- * 
+ *
  * This code is released under the GNU General Public License.
  * See COPYRIGHT.txt and LICENSE.txt.
- * 
+ *
  * This code is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * This header and all notices must be kept intact.
- * 
+ *
  * @author Karim Rahimpur
  * @package groups
  * @since groups 1.8.0
@@ -28,7 +28,7 @@ if ( !defined( 'ABSPATH' ) ) {
  */
 function groups_admin_add_ons() {
 
-	echo '<div class="groups-admin-add-ons">';
+	echo '<div class="groups-admin-add-ons wrap">';
 
 	echo '<h1>';
 	echo __( 'Add-Ons', GROUPS_PLUGIN_DOMAIN );
@@ -190,6 +190,6 @@ function groups_admin_add_ons_sort( $e1, $e2 ) {
 	$i2 = isset( $e2['index'] ) ? $e2['index'] : 0;
 	$t1 = isset( $e1['title'] ) ? $e1['title'] : '';
 	$t2 = isset( $e2['title'] ) ? $e2['title'] : '';
-	
+
 	return $i1 - $i2 + strnatcmp( $t1, $t2 );
 }

--- a/lib/admin/groups-admin-add-ons.php
+++ b/lib/admin/groups-admin-add-ons.php
@@ -181,8 +181,6 @@ function groups_admin_add_ons() {
 	echo '</ul>'; // .add-ons
 
 	echo '</div>'; // .groups-admin-add-ons
-
-	Groups_Help::footer();
 }
 
 function groups_admin_add_ons_sort( $e1, $e2 ) {

--- a/lib/admin/groups-admin-capabilities-add.php
+++ b/lib/admin/groups-admin-capabilities-add.php
@@ -1,19 +1,19 @@
 <?php
 /**
  * groups-admin-capabilities-add.php
- * 
+ *
  * Copyright (c) "kento" Karim Rahimpur www.itthinx.com
- * 
+ *
  * This code is released under the GNU General Public License.
  * See COPYRIGHT.txt and LICENSE.txt.
- * 
+ *
  * This code is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * This header and all notices must be kept intact.
- * 
+ *
  * @author Karim Rahimpur
  * @package groups
  * @since groups 1.0.0
@@ -27,44 +27,42 @@ if ( !defined( 'ABSPATH' ) ) {
  * Show add capability form.
  */
 function groups_admin_capabilities_add() {
-	
+
 	global $wpdb;
-	
+
 	if ( !current_user_can( GROUPS_ADMINISTER_GROUPS ) ) {
 		wp_die( __( 'Access denied.', GROUPS_PLUGIN_DOMAIN ) );
 	}
-	
+
 	$current_url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 	$current_url = remove_query_arg( 'paged', $current_url );
 	$current_url = remove_query_arg( 'action', $current_url );
 	$current_url = remove_query_arg( 'capability_id', $current_url );
-	
+
 	$capability  = isset( $_POST['capability-field'] ) ? $_POST['capability-field'] : '';
 	$description = isset( $_POST['description-field'] ) ? $_POST['description-field'] : '';
-	
+
 	$capability_table = _groups_get_tablename( 'capability' );
-		
+
 	$output =
-		'<div class="manage-capabilities">' .
-		'<div>' .
-			'<h2>' .
+		'<div class="manage-capabilities wrap">' .
+			'<h1>' .
 				__( 'Add a new capability', GROUPS_PLUGIN_DOMAIN ) .
-			'</h2>' .
-		'</div>' .
+			'</h1>' .
 		Groups_Admin::render_messages() .
 		'<form id="add-capability" action="' . esc_url( $current_url ) . '" method="post">' .
 		'<div class="capability new">' .
-		
+
 		'<div class="field">' .
 		'<label for="capability-field" class="field-label first required">' .__( 'Capability', GROUPS_PLUGIN_DOMAIN ) . '</label>' .
 		'<input id="name-field" name="capability-field" class="capability-field" type="text" value="' . esc_attr( stripslashes( $capability ) ) . '"/>' .
 		'</div>' .
-		
+
 		'<div class="field">' .
 		'<label for="description-field" class="field-label description-field">' .__( 'Description', GROUPS_PLUGIN_DOMAIN ) . '</label>' .
 		'<textarea id="description-field" name="description-field" rows="5" cols="45">' . stripslashes( wp_filter_nohtml_kses( $description ) ) . '</textarea>' .
 		'</div>' .
-	
+
 		'<div class="field">' .
 		wp_nonce_field( 'capabilities-add', GROUPS_ADMIN_GROUPS_NONCE, true, false ) .
 		'<input class="button button-primary" type="submit" value="' . __( 'Add', GROUPS_PLUGIN_DOMAIN ) . '"/>' .
@@ -74,9 +72,9 @@ function groups_admin_capabilities_add() {
 		'</div>' . // .capability.new
 		'</form>' .
 		'</div>'; // .manage-capabilities
-	
+
 		echo $output;
-		
+
 	Groups_Help::footer();
 } // function groups_admin_capabilities_add
 
@@ -85,20 +83,20 @@ function groups_admin_capabilities_add() {
  * @return int new capability's id or false if unsuccessful
  */
 function groups_admin_capabilities_add_submit() {
-	
+
 	global $wpdb;
-	
+
 	if ( !current_user_can( GROUPS_ADMINISTER_GROUPS ) ) {
 		wp_die( __( 'Access denied.', GROUPS_PLUGIN_DOMAIN ) );
 	}
-	
+
 	if ( !wp_verify_nonce( $_POST[GROUPS_ADMIN_GROUPS_NONCE], 'capabilities-add' ) ) {
 		wp_die( __( 'Access denied.', GROUPS_PLUGIN_DOMAIN ) );
 	}
-	
-	$capability  = isset( $_POST['capability-field'] ) ? $_POST['capability-field'] : null; 
+
+	$capability  = isset( $_POST['capability-field'] ) ? $_POST['capability-field'] : null;
 	$description = isset( $_POST['description-field'] ) ? $_POST['description-field'] : '';
-	
+
 	$capability_id = Groups_Capability::create( compact( "capability", "description" ) );
 	if ( !$capability_id ) {
 		if ( empty( $capability ) ) {

--- a/lib/admin/groups-admin-capabilities-add.php
+++ b/lib/admin/groups-admin-capabilities-add.php
@@ -74,8 +74,6 @@ function groups_admin_capabilities_add() {
 		'</div>'; // .manage-capabilities
 
 		echo $output;
-
-	Groups_Help::footer();
 } // function groups_admin_capabilities_add
 
 /**

--- a/lib/admin/groups-admin-capabilities-edit.php
+++ b/lib/admin/groups-admin-capabilities-edit.php
@@ -83,8 +83,6 @@ function groups_admin_capabilities_edit( $capability_id ) {
 		'</div>'; // .manage-capabilities
 
 		echo $output;
-
-	Groups_Help::footer();
 } // function groups_admin_capabilities_edit
 
 /**

--- a/lib/admin/groups-admin-capabilities-edit.php
+++ b/lib/admin/groups-admin-capabilities-edit.php
@@ -1,19 +1,19 @@
 <?php
 /**
  * groups-admin-capability-edit.php
- * 
+ *
  * Copyright (c) "kento" Karim Rahimpur www.itthinx.com
- * 
+ *
  * This code is released under the GNU General Public License.
  * See COPYRIGHT.txt and LICENSE.txt.
- * 
+ *
  * This code is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * This header and all notices must be kept intact.
- * 
+ *
  * @author Karim Rahimpur
  * @package groups
  * @since groups 1.0.0
@@ -28,52 +28,50 @@ if ( !defined( 'ABSPATH' ) ) {
  * @param int $capability_id capability id
  */
 function groups_admin_capabilities_edit( $capability_id ) {
-	
+
 	global $wpdb;
-	
+
 	if ( !current_user_can( GROUPS_ADMINISTER_GROUPS ) ) {
 		wp_die( __( 'Access denied.', GROUPS_PLUGIN_DOMAIN ) );
 	}
-	
+
 	$capability = Groups_Capability::read( intval( $capability_id ) );
-	
+
 	if ( empty( $capability ) ) {
 		wp_die( __( 'No such capability.', GROUPS_PLUGIN_DOMAIN ) );
 	}
-	
+
 	$current_url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 	$current_url = remove_query_arg( 'action', $current_url );
 	$current_url = remove_query_arg( 'capability_id', $current_url );
-	
+
 	$capability_capability  = isset( $_POST['capability-field'] ) ? $_POST['capability-field'] : $capability->capability;
 	$description = isset( $_POST['description-field'] ) ? $_POST['description-field'] : $capability->description;
-	
+
 	$capability_readonly = ( $capability->capability !== Groups_Post_Access::READ_POST_CAPABILITY ) ? "" : ' readonly="readonly" ';
-	
+
 	$output =
-		'<div class="manage-capabilities">' .
-		'<div>' .
-			'<h2>' .
+		'<div class="manage-capabilities wrap">' .
+			'<h1>' .
 				__( 'Edit a capability', GROUPS_PLUGIN_DOMAIN ) .
-			'</h2>' .
-		'</div>' .
+			'</h1>' .
 
 		Groups_Admin::render_messages() .
-	
+
 		'<form id="edit-capability" action="' . esc_url( $current_url ) . '" method="post">' .
 		'<div class="capability edit">' .
 		'<input id="capability-id-field" name="capability-id-field" type="hidden" value="' . esc_attr( intval( $capability_id ) ) . '"/>' .
-		
+
 		'<div class="field">' .
 		'<label for="capability-field" class="field-label first required">' .__( 'Capability', GROUPS_PLUGIN_DOMAIN ) . '</label>' .
 		'<input ' . $capability_readonly . ' id="capability-field" name="capability-field" class="capability-field" type="text" value="' . esc_attr( stripslashes( $capability_capability ) ) . '"/>' .
 		'</div>' .
-			
+
 		'<div class="field">' .
 		'<label for="description-field" class="field-label description-field">' .__( 'Description', GROUPS_PLUGIN_DOMAIN ) . '</label>' .
 		'<textarea id="description-field" name="description-field" rows="5" cols="45">' . stripslashes( wp_filter_nohtml_kses( $description ) ) . '</textarea>' .
 		'</div>' .
-	
+
 		'<div class="field">' .
 		wp_nonce_field( 'capabilities-edit', GROUPS_ADMIN_GROUPS_NONCE, true, false ) .
 		'<input class="button button-primary" type="submit" value="' . __( 'Save', GROUPS_PLUGIN_DOMAIN ) . '"/>' .
@@ -83,9 +81,9 @@ function groups_admin_capabilities_edit( $capability_id ) {
 		'</div>' . // .capability.edit
 		'</form>' .
 		'</div>'; // .manage-capabilities
-	
+
 		echo $output;
-	
+
 	Groups_Help::footer();
 } // function groups_admin_capabilities_edit
 

--- a/lib/admin/groups-admin-capabilities-remove.php
+++ b/lib/admin/groups-admin-capabilities-remove.php
@@ -1,19 +1,19 @@
 <?php
 /**
  * groups-admin-capabilities-remove.php
- * 
+ *
  * Copyright (c) "kento" Karim Rahimpur www.itthinx.com
- * 
+ *
  * This code is released under the GNU General Public License.
  * See COPYRIGHT.txt and LICENSE.txt.
- * 
+ *
  * This code is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * This header and all notices must be kept intact.
- * 
+ *
  * @author Karim Rahimpur
  * @package groups
  * @since groups 1.0.0
@@ -48,12 +48,10 @@ function groups_admin_capabilities_remove( $capability_id ) {
 	$current_url = remove_query_arg( 'capability_id', $current_url );
 
 	$output =
-		'<div class="manage-capabilities">' .
-		'<div>' .
-			'<h2>' .
+		'<div class="manage-capabilities wrap">' .
+			'<h1>' .
 				__( 'Remove a capability', GROUPS_PLUGIN_DOMAIN ) .
-			'</h2>' .
-		'</div>' .
+			'</h1>' .
 		'<form id="remove-capability" action="' . esc_url( $current_url ) . '" method="post">' .
 		'<div class="capability remove">' .
 		'<input id="capability-id-field" name="capability-id-field" type="hidden" value="' . esc_attr( intval( $capability->capability_id ) ) . '"/>' .

--- a/lib/admin/groups-admin-capabilities-remove.php
+++ b/lib/admin/groups-admin-capabilities-remove.php
@@ -68,8 +68,6 @@ function groups_admin_capabilities_remove( $capability_id ) {
 		'</div>'; // .manage-capabilities
 
 	echo $output;
-
-	Groups_Help::footer();
 } // function groups_admin_capabilities_remove
 
 /**

--- a/lib/admin/groups-admin-capabilities.php
+++ b/lib/admin/groups-admin-capabilities.php
@@ -279,7 +279,7 @@ function groups_admin_capabilities() {
 	$results = $wpdb->get_results( $query, OBJECT );
 
 	$column_display_names = array(
-		'capability_id' => __( 'Id', GROUPS_PLUGIN_DOMAIN ),
+		'capability_id' => __( 'ID', GROUPS_PLUGIN_DOMAIN ),
 		'capability'	=> __( 'Capability', GROUPS_PLUGIN_DOMAIN ),
 		'description'   => __( 'Description', GROUPS_PLUGIN_DOMAIN )
 	);
@@ -288,20 +288,18 @@ function groups_admin_capabilities() {
 
 	$output .=
 		'<div class="filters">' .
-			'<label class="description" for="setfilters">' . __( 'Filters', GROUPS_PLUGIN_DOMAIN ) . '</label>' .
 			'<form id="setfilters" action="" method="post">' .
-				'<p>' .
-				'<label class="capability-id-filter" for="capability_id">' . __( 'Capability Id', GROUPS_PLUGIN_DOMAIN ) . '</label>' .
+				'<fieldset>' .
+				'<legend>' . __( 'Filter By:', GROUPS_PLUGIN_DOMAIN ) . '</legend>' .
+				'<label class="capability-id-filter" for="capability_id">' . __( 'Capability ID', GROUPS_PLUGIN_DOMAIN ) . '</label>' .
 				'<input class="capability-id-filter" name="capability_id" type="text" value="' . esc_attr( $capability_id ) . '"/>' .
 				'<label class="capability-filter" for="capability">' . __( 'Capability', GROUPS_PLUGIN_DOMAIN ) . '</label>' .
 				'<input class="capability-filter" name="capability" type="text" value="' . $capability . '"/>' .
-				'</p>' .
-				'<p>' .
 				wp_nonce_field( 'admin', GROUPS_ADMIN_CAPABILITIES_FILTER_NONCE, true, false ) .
-				'<input class="button" type="submit" value="' . __( 'Apply', GROUPS_PLUGIN_DOMAIN ) . '"/>' .
+				'<input class="button" type="submit" value="' . __( 'Apply', GROUPS_PLUGIN_DOMAIN ) . '"/>&nbsp;' .
 				'<input class="button" type="submit" name="clear_filters" value="' . __( 'Clear', GROUPS_PLUGIN_DOMAIN ) . '"/>' .
 				'<input type="hidden" value="submitted" name="submitted"/>' .
-				'</p>' .
+				'</fieldset>' .
 			'</form>' .
 		'</div>';
 

--- a/lib/admin/groups-admin-capabilities.php
+++ b/lib/admin/groups-admin-capabilities.php
@@ -376,6 +376,7 @@ function groups_admin_capabilities() {
 
 	if ( count( $results ) > 0 ) {
 		for ( $i = 0; $i < count( $results ); $i++ ) {
+			$result = $results[$i];
 
 			// Construct the "edit" URL.
 			$edit_url = add_query_arg( 'capability_id', intval( $result->capability_id ), add_query_arg( 'action', 'edit', add_query_arg( 'paged', $paged, $current_url ) ) );
@@ -384,8 +385,6 @@ function groups_admin_capabilities() {
 
 			// Construct row actions for this group.
 			$row_actions = '<div class="row-actions">' . '<span class="edit"><a href="' . esc_url( $edit_url ) . '">' . __( 'Edit', GROUPS_PLUGIN_DOMAIN ) . '</a> | </span><span class="trash"><a href="' . esc_url( $delete_url ) . '" class="submitdelete">' . __( 'Remove', GROUPS_PLUGIN_DOMAIN ) . '</a></span>' . '</div><!--/.row-actions-->' . "\n";
-
-			$result = $results[$i];
 
 			$output .= '<tr class="' . ( $i % 2 == 0 ? 'even' : 'odd' ) . '">';
 

--- a/lib/admin/groups-admin-capabilities.php
+++ b/lib/admin/groups-admin-capabilities.php
@@ -118,9 +118,9 @@ function groups_admin_capabilities() {
 				if ( check_admin_referer( 'refresh' ) ) {
 					$n = Groups_WordPress::refresh_capabilities();
 					if ( $n > 0 ) {
-						$output .= '<div class="info">' . sprintf( _n( 'One capability has been added.', '%d capabilities have been added.', $n, GROUPS_PLUGIN_DOMAIN ), $n ) . '</div>';
+						$output .= '<div class="updated fade"><p>' . sprintf( _n( 'One capability has been added.', '%d capabilities have been added.', $n, GROUPS_PLUGIN_DOMAIN ), $n ) . '</p></div>';
 					} else {
-						$output .= '<div class="info">' . __( 'No new capabilities have been found.', GROUPS_PLUGIN_DOMAIN ) .  '</div>';
+						$output .= '<div class="updated fade"><p>' . __( 'No new capabilities have been found.', GROUPS_PLUGIN_DOMAIN ) .  '</p></div>';
 					}
 				} else {
 					wp_die( __( 'A Duck!', GROUPS_PLUGIN_DOMAIN ) );

--- a/lib/admin/groups-admin-capabilities.php
+++ b/lib/admin/groups-admin-capabilities.php
@@ -281,9 +281,7 @@ function groups_admin_capabilities() {
 	$column_display_names = array(
 		'capability_id' => __( 'Id', GROUPS_PLUGIN_DOMAIN ),
 		'capability'	=> __( 'Capability', GROUPS_PLUGIN_DOMAIN ),
-		'description'   => __( 'Description', GROUPS_PLUGIN_DOMAIN ),
-		'edit'		  => __( 'Edit', GROUPS_PLUGIN_DOMAIN ),
-		'remove'		=> __( 'Remove', GROUPS_PLUGIN_DOMAIN )
+		'description'   => __( 'Description', GROUPS_PLUGIN_DOMAIN )
 	);
 
 	$output .= '<div class="capabilities-overview">';
@@ -379,6 +377,14 @@ function groups_admin_capabilities() {
 	if ( count( $results ) > 0 ) {
 		for ( $i = 0; $i < count( $results ); $i++ ) {
 
+			// Construct the "edit" URL.
+			$edit_url = add_query_arg( 'capability_id', intval( $result->capability_id ), add_query_arg( 'action', 'edit', add_query_arg( 'paged', $paged, $current_url ) ) );
+			// Construct the "delete" URL.
+			$delete_url = add_query_arg( 'capability_id', intval( $result->capability_id ), add_query_arg( 'action', 'remove', add_query_arg( 'paged', $paged, $current_url ) ) );
+
+			// Construct row actions for this group.
+			$row_actions = '<div class="row-actions">' . '<span class="edit"><a href="' . esc_url( $edit_url ) . '">' . __( 'Edit', GROUPS_PLUGIN_DOMAIN ) . '</a> | </span><span class="trash"><a href="' . esc_url( $delete_url ) . '" class="submitdelete">' . __( 'Remove', GROUPS_PLUGIN_DOMAIN ) . '</a></span>' . '</div><!--/.row-actions-->' . "\n";
+
 			$result = $results[$i];
 
 			$output .= '<tr class="' . ( $i % 2 == 0 ? 'even' : 'odd' ) . '">';
@@ -390,18 +396,8 @@ function groups_admin_capabilities() {
 			$output .= "<td class='capability-id'>";
 			$output .= $result->capability_id;
 			$output .= "</td>";
-			$output .= "<td class='capability'>" . stripslashes( wp_filter_nohtml_kses( $result->capability ) ) . "</td>";
+			$output .= "<td class='capability'>" . '<a href="' . esc_url( $edit_url ) . '">' . stripslashes( wp_filter_nohtml_kses( $result->capability ) ) . '</a>' . $row_actions . "</td>";
 			$output .= "<td class='description'>" . stripslashes( wp_filter_nohtml_kses( $result->description ) ) . "</td>";
-
-			$output .= "<td class='edit'>";
-			$output .= "<a href='" . esc_url( add_query_arg( 'paged', $paged, $current_url ) ) . "&action=edit&capability_id=" . $result->capability_id . "' alt='" . __( 'Edit', GROUPS_PLUGIN_DOMAIN) . "'><img src='". GROUPS_PLUGIN_URL ."images/edit.png'/></a>";
-			$output .= "</td>";
-
-			$output .= "<td class='remove'>";
-			if ( $result->capability !== Groups_Post_Access::READ_POST_CAPABILITY ) {
-				$output .= "<a href='" . esc_url( $current_url ) . "&action=remove&capability_id=" . $result->capability_id . "' alt='" . __( 'Remove', GROUPS_PLUGIN_DOMAIN) . "'><img src='". GROUPS_PLUGIN_URL ."images/remove.png'/></a>";
-			}
-			$output .= "</td>";
 
 			$output .= '</tr>';
 		}

--- a/lib/admin/groups-admin-capabilities.php
+++ b/lib/admin/groups-admin-capabilities.php
@@ -421,5 +421,4 @@ function groups_admin_capabilities() {
 	$output .= '</div>'; // .manage-capabilities
 
 	echo $output;
-	Groups_Help::footer();
 } // function groups_admin_capabilities()

--- a/lib/admin/groups-admin-capabilities.php
+++ b/lib/admin/groups-admin-capabilities.php
@@ -1,19 +1,19 @@
 <?php
 /**
  * groups-admin-capabilities.php
- * 
+ *
  * Copyright (c) "kento" Karim Rahimpur www.itthinx.com
- * 
+ *
  * This code is released under the GNU General Public License.
  * See COPYRIGHT.txt and LICENSE.txt.
- * 
+ *
  * This code is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * This header and all notices must be kept intact.
- * 
+ *
  * @author Karim Rahimpur
  * @package groups
  * @since groups 1.0.0
@@ -187,20 +187,14 @@ function groups_admin_capabilities() {
 	$capability_table = _groups_get_tablename( 'capability' );
 
 	$output .=
-		'<div class="manage-capabilities">' .
-		'<div>' .
-		'<h2>' .
+		'<div class="manage-capabilities wrap">' .
+		'<h1>' .
 		__( 'Capabilities', GROUPS_PLUGIN_DOMAIN ) .
-		'</h2>' .
-		'</div>';
-	
+		" <a title='" . __( 'Click to add a new capability', GROUPS_PLUGIN_DOMAIN ) . "' class='page-title-action' href='" . esc_url( $current_url ) . "&action=add'><span class='label'>" . __( 'Add New Capability', GROUPS_PLUGIN_DOMAIN) . "</span></a>" .
+		" <a title='" . __( 'Click to refresh capabilities', GROUPS_PLUGIN_DOMAIN ) . "' class='page-title-action' href='" . esc_url( wp_nonce_url( $current_url, 'refresh' ) ) . "&action=refresh'><span class='label'>" . __( 'Refresh Capabilities', GROUPS_PLUGIN_DOMAIN ) . "</span></a>" .
+		'</h1>';
+
 	$output .= Groups_Admin::render_messages();
-	
-	$output .=
-		'<div class="manage">' .
-		"<a title='" . __( 'Click to add a new capability', GROUPS_PLUGIN_DOMAIN ) . "' class='add button' href='" . esc_url( $current_url ) . "&action=add'><img class='icon' alt='" . __( 'Add', GROUPS_PLUGIN_DOMAIN) . "' src='". GROUPS_PLUGIN_URL . "images/add.png'/><span class='label'>" . __( 'New Capability', GROUPS_PLUGIN_DOMAIN) . "</span></a>" .
-		"<a title='" . __( 'Click to refresh capabilities', GROUPS_PLUGIN_DOMAIN ) . "' class='refresh button' href='" . esc_url( wp_nonce_url( $current_url, 'refresh' ) ) . "&action=refresh'><img class='icon' alt='" . __( 'Refresh', GROUPS_PLUGIN_DOMAIN) . "' src='". GROUPS_PLUGIN_URL . "images/refresh.png'/><span class='label'></span></a>" .
-		'</div>';
 
 	$row_count = isset( $_POST['row_count'] ) ? intval( $_POST['row_count'] ) : 0;
 

--- a/lib/admin/groups-admin-groups-add.php
+++ b/lib/admin/groups-admin-groups-add.php
@@ -123,8 +123,6 @@ function groups_admin_groups_add() {
 	$output .= '</div>'; // .manage-groups
 
 	echo $output;
-
-	Groups_Help::footer();
 } // function groups_admin_groups_add
 
 /**

--- a/lib/admin/groups-admin-groups-add.php
+++ b/lib/admin/groups-admin-groups-add.php
@@ -1,19 +1,19 @@
 <?php
 /**
  * groups-admin-groups-add.php
- * 
+ *
  * Copyright (c) "kento" Karim Rahimpur www.itthinx.com
- * 
+ *
  * This code is released under the GNU General Public License.
  * See COPYRIGHT.txt and LICENSE.txt.
- * 
+ *
  * This code is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * This header and all notices must be kept intact.
- * 
+ *
  * @author Karim Rahimpur
  * @package groups
  * @since groups 1.1.0
@@ -54,12 +54,10 @@ function groups_admin_groups_add() {
 	}
 	$parent_select .= '</select>';
 
-	$output .= '<div class="manage-groups">';
-	$output .= '<div>';
-	$output .= '<h2>';
+	$output .= '<div class="manage-groups wrap">';
+	$output .= '<h1>';
 	$output .= __( 'Add a new group', GROUPS_PLUGIN_DOMAIN );
-	$output .= '</h2>';
-	$output .= '</div>';
+	$output .= '</h1>';
 
 	$output .= Groups_Admin::render_messages();
 

--- a/lib/admin/groups-admin-groups-edit.php
+++ b/lib/admin/groups-admin-groups-edit.php
@@ -1,19 +1,19 @@
 <?php
 /**
  * groups-admin-groups-edit.php
- * 
+ *
  * Copyright (c) "kento" Karim Rahimpur www.itthinx.com
- * 
+ *
  * This code is released under the GNU General Public License.
  * See COPYRIGHT.txt and LICENSE.txt.
- * 
+ *
  * This code is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * This header and all notices must be kept intact.
- * 
+ *
  * @author Karim Rahimpur
  * @package groups
  * @since groups 1.1.0
@@ -63,12 +63,10 @@ function groups_admin_groups_edit( $group_id ) {
 
 	$name_readonly = ( $name !== Groups_Registered::REGISTERED_GROUP_NAME ) ? "" : ' readonly="readonly" ';
 
-	$output .= '<div class="manage-groups">';
-	$output .= '<div>';
-	$output .= '<h2>';
+	$output .= '<div class="manage-groups wrap">';
+	$output .= '<h1>';
 	$output .= __( 'Edit a group', GROUPS_PLUGIN_DOMAIN );
-	$output .= '</h2>';
-	$output .= '</div>';
+	$output .= '</h1>';
 
 	$output .= Groups_Admin::render_messages();
 

--- a/lib/admin/groups-admin-groups-edit.php
+++ b/lib/admin/groups-admin-groups-edit.php
@@ -162,8 +162,6 @@ function groups_admin_groups_edit( $group_id ) {
 	$output .= '</div>'; // .manage-groups
 
 	echo $output;
-
-	Groups_Help::footer();
 } // function groups_admin_groups_edit
 
 /**

--- a/lib/admin/groups-admin-groups-remove.php
+++ b/lib/admin/groups-admin-groups-remove.php
@@ -68,8 +68,6 @@ function groups_admin_groups_remove( $group_id ) {
 		'</div>'; // .manage-groups
 
 	echo $output;
-
-	Groups_Help::footer();
 } // function groups_admin_groups_remove
 
 /**

--- a/lib/admin/groups-admin-groups-remove.php
+++ b/lib/admin/groups-admin-groups-remove.php
@@ -1,19 +1,19 @@
 <?php
 /**
  * groups-admin-groups-remove.php
- * 
+ *
  * Copyright (c) "kento" Karim Rahimpur www.itthinx.com
- * 
+ *
  * This code is released under the GNU General Public License.
  * See COPYRIGHT.txt and LICENSE.txt.
- * 
+ *
  * This code is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * This header and all notices must be kept intact.
- * 
+ *
  * @author Karim Rahimpur
  * @package groups
  * @since groups 1.1.0
@@ -28,32 +28,30 @@ if ( !defined( 'ABSPATH' ) ) {
  * @param int $group_id group id
  */
 function groups_admin_groups_remove( $group_id ) {
-	
+
 	global $wpdb;
-	
+
 	if ( !current_user_can( GROUPS_ADMINISTER_GROUPS ) ) {
 		wp_die( __( 'Access denied.', GROUPS_PLUGIN_DOMAIN ) );
 	}
-	
+
 	$group = Groups_Group::read( intval( $group_id ) );
-	
+
 	if ( empty( $group ) ) {
 		wp_die( __( 'No such group.', GROUPS_PLUGIN_DOMAIN ) );
 	}
-	
+
 	$group_table = _groups_get_tablename( 'group' );
 
 	$current_url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 	$current_url = remove_query_arg( 'action', $current_url );
 	$current_url = remove_query_arg( 'group_id', $current_url );
-	
+
 	$output =
-		'<div class="manage-groups">' .
-		'<div>' .
-		'<h2>' .
+		'<div class="manage-groups wrap">' .
+		'<h1>' .
 		__( 'Remove a group', GROUPS_PLUGIN_DOMAIN ) .
-		'</h2>' .
-		'</div>' .
+		'</h1>' .
 		'<form id="remove-group" action="' . esc_url( $current_url ) . '" method="post">' .
 		'<div class="group remove">' .
 		'<input id="group-id-field" name="group-id-field" type="hidden" value="' . esc_attr( intval( $group->group_id ) ) . '"/>' .
@@ -68,9 +66,9 @@ function groups_admin_groups_remove( $group_id ) {
 		'</div>' . // .group.remove
 		'</form>' .
 		'</div>'; // .manage-groups
-	
+
 	echo $output;
-	
+
 	Groups_Help::footer();
 } // function groups_admin_groups_remove
 
@@ -78,19 +76,19 @@ function groups_admin_groups_remove( $group_id ) {
  * Handle remove form submission.
  */
 function groups_admin_groups_remove_submit() {
-	
+
 	global $wpdb;
-	
+
 	$result = false;
-	
+
 	if ( !current_user_can( GROUPS_ADMINISTER_GROUPS ) ) {
 		wp_die( __( 'Access denied.', GROUPS_PLUGIN_DOMAIN ) );
 	}
-	
+
 	if ( !wp_verify_nonce( $_POST[GROUPS_ADMIN_GROUPS_NONCE], 'groups-remove' ) ) {
 		wp_die( __( 'Access denied.', GROUPS_PLUGIN_DOMAIN ) );
 	}
-	
+
 	$group_id = isset( $_POST['group-id-field'] ) ? $_POST['group-id-field'] : null;
 	$group = Groups_Group::read( $group_id );
 	if ( $group ) {

--- a/lib/admin/groups-admin-groups.php
+++ b/lib/admin/groups-admin-groups.php
@@ -288,9 +288,7 @@ function groups_admin_groups() {
 		'group_id'	 => __( 'Id', GROUPS_PLUGIN_DOMAIN ),
 		'name'		 => __( 'Group', GROUPS_PLUGIN_DOMAIN ),
 		'description'  => __( 'Description', GROUPS_PLUGIN_DOMAIN ),
-		'capabilities' => __( 'Capabilities', GROUPS_PLUGIN_DOMAIN ),
-		'edit'		 => __( 'Edit', GROUPS_PLUGIN_DOMAIN ),
-		'remove'	   => __( 'Remove', GROUPS_PLUGIN_DOMAIN )
+		'capabilities' => __( 'Capabilities', GROUPS_PLUGIN_DOMAIN )
 	);
 
 	$output .= '<div class="groups-overview">';
@@ -386,7 +384,7 @@ function groups_admin_groups() {
 			'order' => $switch_order
 		);
 		$class = $key;
-		if ( !in_array($key, array( 'capabilities', 'edit', 'remove' ) ) ) {
+		if ( !in_array($key, array( 'capabilities' ) ) ) {
 			if ( strcmp( $key, $orderby ) == 0 ) {
 				$lorder = strtolower( $order );
 				$class = "$key manage-column sorted $lorder";
@@ -407,6 +405,14 @@ function groups_admin_groups() {
 
 			$result = $results[$i];
 
+			// Construct the "edit" URL.
+			$edit_url = add_query_arg( 'group_id', intval( $result->group_id ), add_query_arg( 'action', 'edit', add_query_arg( 'paged', $paged, $current_url ) ) );
+			// Construct the "delete" URL.
+			$delete_url = add_query_arg( 'group_id', intval( $result->group_id ), add_query_arg( 'action', 'remove', add_query_arg( 'paged', $paged, $current_url ) ) );
+
+			// Construct row actions for this group.
+			$row_actions = '<div class="row-actions">' . '<span class="edit"><a href="' . esc_url( $edit_url ) . '">' . __( 'Edit', GROUPS_PLUGIN_DOMAIN ) . '</a> | </span><span class="trash"><a href="' . esc_url( $delete_url ) . '" class="submitdelete">' . __( 'Remove', GROUPS_PLUGIN_DOMAIN ) . '</a></span>' . '</div><!--/.row-actions-->' . "\n";
+
 			$output .= '<tr class="' . ( $i % 2 == 0 ? 'even' : 'odd' ) . '">';
 
 			$output .= '<th class="check-column">';
@@ -416,7 +422,7 @@ function groups_admin_groups() {
 			$output .= "<td class='group-id'>";
 			$output .= $result->group_id;
 			$output .= "</td>";
-			$output .= "<td class='group-name'>" . stripslashes( wp_filter_nohtml_kses( $result->name ) ) . "</td>";
+			$output .= "<td class='group-name'>" . '<a href="' . esc_url( $edit_url ) . '">' . stripslashes( wp_filter_nohtml_kses( $result->name ) ) . '</a>' . $row_actions . "</td>";
 			$output .= "<td class='group-description'>" . stripslashes( wp_filter_nohtml_kses( $result->description ) ) . "</td>";
 
 			$output .= '<td class="capabilities">';
@@ -446,16 +452,6 @@ function groups_admin_groups() {
 				$output .= __( 'This group has no capabilities.', GROUPS_PLUGIN_DOMAIN );
 			}
 			$output .= '</td>';
-
-			$output .= "<td class='edit'>";
-			$output .= "<a href='" . esc_url( add_query_arg( 'paged', $paged, $current_url ) ) . "&action=edit&group_id=" . $result->group_id . "' alt='" . __( 'Edit', GROUPS_PLUGIN_DOMAIN) . "'><img src='". GROUPS_PLUGIN_URL ."images/edit.png'/></a>";
-			$output .= "</td>";
-
-			$output .= "<td class='remove'>";
-			if ( $result->name !== Groups_Registered::REGISTERED_GROUP_NAME ) {
-				$output .= "<a href='" . esc_url( $current_url ) . "&action=remove&group_id=" . $result->group_id . "' alt='" . __( 'Remove', GROUPS_PLUGIN_DOMAIN) . "'><img src='". GROUPS_PLUGIN_URL ."images/remove.png'/></a>";
-			}
-			$output .= "</td>";
 
 			$output .= '</tr>';
 		}

--- a/lib/admin/groups-admin-groups.php
+++ b/lib/admin/groups-admin-groups.php
@@ -285,7 +285,7 @@ function groups_admin_groups() {
 	$results = $wpdb->get_results( $query, OBJECT );
 
 	$column_display_names = array(
-		'group_id'	 => __( 'Id', GROUPS_PLUGIN_DOMAIN ),
+		'group_id'	 => __( 'ID', GROUPS_PLUGIN_DOMAIN ),
 		'name'		 => __( 'Group', GROUPS_PLUGIN_DOMAIN ),
 		'description'  => __( 'Description', GROUPS_PLUGIN_DOMAIN ),
 		'capabilities' => __( 'Capabilities', GROUPS_PLUGIN_DOMAIN )
@@ -295,20 +295,18 @@ function groups_admin_groups() {
 
 	$output .=
 		'<div class="filters">' .
-			'<label class="description" for="setfilters">' . __( 'Filters', GROUPS_PLUGIN_DOMAIN ) . '</label>' .
 			'<form id="setfilters" action="" method="post">' .
-				'<p>' .
-				'<label class="group-id-filter" for="group_id">' . __( 'Group Id', GROUPS_PLUGIN_DOMAIN ) . '</label>' .
+				'<fieldset>' .
+				'<legend>' . __( 'Filter By:', GROUPS_PLUGIN_DOMAIN ) . '</legend>' .
+				'<label class="group-id-filter" for="group_id">' . __( 'Group ID', GROUPS_PLUGIN_DOMAIN ) . '</label>' .
 				'<input class="group-id-filter" name="group_id" type="text" value="' . esc_attr( $group_id ) . '"/>' .
 				'<label class="group-name-filter" for="group_name">' . __( 'Group Name', GROUPS_PLUGIN_DOMAIN ) . '</label>' .
 				'<input class="group-name-filter" name="group_name" type="text" value="' . $group_name . '"/>' .
-				'</p>' .
-				'<p>' .
 				wp_nonce_field( 'admin', GROUPS_ADMIN_GROUPS_FILTER_NONCE, true, false ) .
-				'<input class="button" type="submit" value="' . __( 'Apply', GROUPS_PLUGIN_DOMAIN ) . '"/>' .
+				'<input class="button" type="submit" value="' . __( 'Apply', GROUPS_PLUGIN_DOMAIN ) . '"/>&nbsp;' .
 				'<input class="button" type="submit" name="clear_filters" value="' . __( 'Clear', GROUPS_PLUGIN_DOMAIN ) . '"/>' .
 				'<input type="hidden" value="submitted" name="submitted"/>' .
-				'</p>' .
+				'</fieldset>' .
 			'</form>' .
 		'</div>';
 

--- a/lib/admin/groups-admin-groups.php
+++ b/lib/admin/groups-admin-groups.php
@@ -1,19 +1,19 @@
 <?php
 /**
  * groups-admin-groups.php
- * 
+ *
  * Copyright (c) "kento" Karim Rahimpur www.itthinx.com
- * 
+ *
  * This code is released under the GNU General Public License.
  * See COPYRIGHT.txt and LICENSE.txt.
- * 
+ *
  * This code is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * This header and all notices must be kept intact.
- * 
+ *
  * @author Karim Rahimpur
  * @package groups
  * @since groups 1.0.0
@@ -194,19 +194,13 @@ function groups_admin_groups() {
 	$group_table = _groups_get_tablename( 'group' );
 
 	$output .=
-		'<div class="manage-groups">' .
-		'<div>' .
-		'<h2>' .
+		'<div class="manage-groups wrap">' .
+		'<h1>' .
 		_x( 'Groups', 'page-title', GROUPS_PLUGIN_DOMAIN ) .
-		'</h2>' .
-		'</div>';
+		" <a title='" . __( 'Click to add a new group', GROUPS_PLUGIN_DOMAIN ) . "' class='page-title-action' href='" . esc_url( $current_url ) . "&action=add'><span class='label'>" . __( 'Add New Group', GROUPS_PLUGIN_DOMAIN) . "</span></a>" .
+		'</h1>';
 
 	$output .= Groups_Admin::render_messages();
-
-	$output .=
-		'<div class="manage">' .
-		"<a title='" . __( 'Click to add a new group', GROUPS_PLUGIN_DOMAIN ) . "' class='add button' href='" . esc_url( $current_url ) . "&action=add'><img class='icon' alt='" . __( 'Add', GROUPS_PLUGIN_DOMAIN) . "' src='". GROUPS_PLUGIN_URL ."images/add.png'/><span class='label'>" . __( 'New Group', GROUPS_PLUGIN_DOMAIN) . "</span></a>" .
-		'</div>';
 
 	$row_count = isset( $_POST['row_count'] ) ? intval( $_POST['row_count'] ) : 0;
 
@@ -222,7 +216,7 @@ function groups_admin_groups() {
 	$paged = isset( $_REQUEST['paged'] ) ? intval( $_REQUEST['paged'] ) : 0;
 	if ( $paged < 0 ) {
 		$paged = 0;
-	} 
+	}
 
 	$orderby = isset( $_GET['orderby'] ) ? $_GET['orderby'] : null;
 	switch ( $orderby ) {

--- a/lib/admin/groups-admin-groups.php
+++ b/lib/admin/groups-admin-groups.php
@@ -476,5 +476,4 @@ function groups_admin_groups() {
 	$output .= '</div>'; // .manage-groups
 
 	echo $output;
-	Groups_Help::footer();
 } // function groups_admin_groups()

--- a/lib/admin/groups-admin-options.php
+++ b/lib/admin/groups-admin-options.php
@@ -1,19 +1,19 @@
 <?php
 /**
  * groups-admin-options.php
- * 
+ *
  * Copyright (c) "kento" Karim Rahimpur www.itthinx.com
- * 
+ *
  * This code is released under the GNU General Public License.
  * See COPYRIGHT.txt and LICENSE.txt.
- * 
+ *
  * This code is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * This header and all notices must be kept intact.
- * 
+ *
  * @author Karim Rahimpur
  * @package groups
  * @since groups 1.0.0
@@ -126,12 +126,12 @@ function groups_admin_options() {
 		}
 	}
 
-	echo '<div class="groups-options">';
+	echo '<div class="groups-options wrap">';
 
 	echo
-		'<h2>' .
-		__( 'Groups options', GROUPS_PLUGIN_DOMAIN ) .
-		'</h2>';
+		'<h1>' .
+		__( 'Groups Options', GROUPS_PLUGIN_DOMAIN ) .
+		'</h1>';
 
 	echo Groups_Admin::render_messages();
 
@@ -169,7 +169,7 @@ function groups_admin_options() {
 			} else {
 				$checked = '';
 			}
-			 
+
 			$caps_table .= '<td class="checkbox">';
 			$role_cap_id = $rolekey.'-'.$capkey;
 			$caps_table .= '<input type="checkbox" name="' . $role_cap_id . '" id="' . $role_cap_id . '" ' . $checked . '/>';

--- a/lib/admin/groups-admin-options.php
+++ b/lib/admin/groups-admin-options.php
@@ -320,7 +320,6 @@ function groups_admin_options() {
 		'</form>';
 
 	echo '</div>'; // .groups-options
-	Groups_Help::footer();
 }
 
 function groups_network_admin_options() {
@@ -368,5 +367,4 @@ function groups_network_admin_options() {
 		'</p>' .
 		'</div>' .
 		'</form>';
-	Groups_Help::footer();
 }

--- a/lib/admin/groups-admin-tree-view.php
+++ b/lib/admin/groups-admin-tree-view.php
@@ -1,19 +1,19 @@
 <?php
 /**
  * groups-admin-tree-view.php
- * 
+ *
  * Copyright (c) "kento" Karim Rahimpur www.itthinx.com
- * 
+ *
  * This code is released under the GNU General Public License.
  * See COPYRIGHT.txt and LICENSE.txt.
- * 
+ *
  * This code is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * This header and all notices must be kept intact.
- * 
+ *
  * @author Karim Rahimpur
  * @package groups
  * @since groups 1.0.0
@@ -51,5 +51,4 @@ function groups_admin_tree_view() {
 	$output .= '</div>'; // .groups-tree-view
 
 	echo $output;
-	Groups_Help::footer();
 } // function groups_admin_tree_view()

--- a/lib/core/class-groups-help.php
+++ b/lib/core/class-groups-help.php
@@ -27,7 +27,7 @@ if ( !defined( 'ABSPATH' ) ) {
  * Help renderer.
  */
 class Groups_Help {
-	
+
 	/**
 	 * Help setup.
 	 */
@@ -39,11 +39,15 @@ class Groups_Help {
 				include_once( GFA_VIEWS_LIB . '/class-gfa-help.php' );
 			}
 		}
+
+		if ( is_admin() && isset( $_GET['page'] ) && 'groups-' == substr( $_GET['page'], 0, 7 ) ) {
+			add_filter( 'admin_footer_text', array( __CLASS__, 'add_groups_footer' ) );
+		}
 	}
-	
+
 	/**
 	 * Adds contextual help to Groups admin screens.
-	 * 
+	 *
 	 * @param array $pages admin pages
 	 */
 	public static function groups_admin_menu( $pages ) {
@@ -51,7 +55,7 @@ class Groups_Help {
 			add_action( 'load-' . $page, array( __CLASS__, 'contextual_help' ) );
 		}
 	}
-	
+
 	/**
 	 * Adds help to an admin screen.
 	 */
@@ -106,13 +110,30 @@ class Groups_Help {
 	}
 
 	/**
+	 * Add Groups footer text to the main WordPress footer text.
+	 * @param string $footer_text Existing WordPress footer text.
+	 */
+	public static function add_groups_footer ( $footer_text ) {
+		$footer_text .= ' ' . Groups_Help::get_groups_footer_text();
+		return $footer_text;
+	}
+
+	/**
+	 * Return the Groups footer text.
+	 * @return string Groups footer text.
+	 */
+	public static function get_groups_footer_text () {
+		return apply_filters( 'groups_footer_text', '<em>' . __( 'Thank you for using <a href="http://www.itthinx.com/plugins/groups" target="_blank">Groups</a> by <a href="http://www.itthinx.com" target="_blank">itthinx</a>.</em>', GROUPS_PLUGIN_DOMAIN ) );
+	}
+
+	/**
 	 * Returns or renders the footer.
 	 * @param boolean $render
 	 */
 	public static function footer( $render = true ) {
 		$footer =
 			'<div class="groups-footer">' .
-			__( 'Thank you for using <a href="http://www.itthinx.com/plugins/groups" target="_blank">Groups</a> by <a href="http://www.itthinx.com" target="_blank">itthinx</a>.', GROUPS_PLUGIN_DOMAIN ) .
+			Groups_Help::get_groups_footer_text() .
 			'</div>';
 		$footer = apply_filters( 'groups_footer', $footer );
 		if ( $render ) {


### PR DESCRIPTION
This pull request aims to refresh the main management, options, and Addons screens of the Groups UI.

While this plugin addresses page headings on the add, edit, and remove screens, the remainder of these screens remains unaddressed, as it makes more sense (to me) to refactor these screens to resemble the WordPress taxonomy management UI (ie: "add" action happens on the same screen as the management of the items).

An example of the management screen, before and after:

Before:
![image](https://cloud.githubusercontent.com/assets/880803/11443612/14f515d8-9527-11e5-8f53-b7c9320f3474.png)

After:
![image](https://cloud.githubusercontent.com/assets/880803/11443588/f54a994c-9526-11e5-9b3a-a1bfd66dd006.png)

I feel these updates improve screen real estate usage, while also helping to future-proof the visuals of the plugin for future versions of WordPress.

Thoughts, @itthinx ?
