### PR TITLE
Added filter for the potential of pre-selecting available capabilities

### DIFF
--- a/lib/access/class-groups-access-meta-boxes.php
+++ b/lib/access/class-groups-access-meta-boxes.php
@@ -237,7 +237,11 @@ class Groups_Access_Meta_Boxes {
 						} else {
 							$label_title = __( 'No groups grant access through this capability. To grant access to group members using this capability, you should assign it to a group and enable the capability for access restriction.', GROUPS_PLUGIN_DOMAIN );
 						}
-						$output .= sprintf( '<option value="%s" %s>', esc_attr( $capability->capability_id ), in_array( $capability->capability, $read_caps ) ? ' selected="selected" ' : '' );
+
+						$esc_capability_id = esc_attr($capability->capability_id);
+						$selected = apply_filters( 'groups_edit_post_selected_caps', in_array( $capability->capability, $read_caps )? ' selected="selected" ': '', $capability->capability, $esc_capability_id, $read_caps );
+						
+						$output .= sprintf( '<option value="%s" %s>', $esc_capability_id, $selected );
 						$output .= wp_filter_nohtml_kses( $capability->capability );
 						if ( $show_groups ) {
 							if ( count( $group_names ) > 0 ) {


### PR DESCRIPTION
Filter: groups_edit_post_selected_caps
Purpose: Allow for the automatic pre-selection of capabilities for posts.
Example use: Setting up a custom post type that requires default read capabilities without requiring site/content managers to have to remember to edit the meta box every time.
Variables: 4
example usage:

```
add_filter( 'groups_edit_post_selected_caps', 'select_default_capabilities', 10, 4);
/*
* @param string $selected The text added to the option element within the select. Either an empty string or '  selected="selected" ' are default to return. Other option element attributes could be passed back as well. This param must be returned or previously selected capabilities won't display
* @param string $capability_name the name of the capability as set in capabilities editor
* @param string $capability_id the escaped ID of the capability being evaluated
* @param array $previous_selected An array of capabilities already selected in a previously saved post.
*/
function select_default_capabilities($selected, $capability_name, $capability_id, $previous_selected) {
    global $post;
    if( $post->post_type === 'my_custom_post_type' && $capability_name === 'groups_read_post' && empty($post->post_title) ) {

        // This is a new post because the post title is empty
			
        $selected = ' selected="selected" ';

    }
		
    return $selected;
}
```