### PR TITLE
Prevent n+1 problem

### DIFF
--- a/lib/core/class-groups-group.php
+++ b/lib/core/class-groups-group.php
@@ -137,13 +137,13 @@ class Groups_Group implements I_Capable {
 				case 'users' :
 					$user_group_table = _groups_get_tablename( "user_group" );
 					$users = $wpdb->get_results( $wpdb->prepare(
-						"SELECT ID FROM $wpdb->users LEFT JOIN $user_group_table ON $wpdb->users.ID = $user_group_table.user_id WHERE $user_group_table.group_id = %d",
+						"SELECT $wpdb->users.* FROM $wpdb->users LEFT JOIN $user_group_table ON $wpdb->users.ID = $user_group_table.user_id WHERE $user_group_table.group_id = %d",
 						Groups_Utility::id( $this->group->group_id )
 					) );
 					if ( $users ) {
 						$result = array();
 						foreach( $users as $user ) {
-							$result[] = new Groups_User( $user->ID );
+							$result[] = new Groups_User( $user );
 						}
 					}
 					break;

--- a/lib/core/class-groups-group.php
+++ b/lib/core/class-groups-group.php
@@ -141,6 +141,7 @@ class Groups_Group implements I_Capable {
 						Groups_Utility::id( $this->group->group_id )
 					) );
 					if ( $users ) {
+						$this->cache_meta_data( $users );
 						$result = array();
 						foreach( $users as $user ) {
 							$result[] = new Groups_User( $user );
@@ -150,6 +151,30 @@ class Groups_Group implements I_Capable {
 			}
 		}
 		return $result;
+	}
+
+	private function cache_meta_data( $users ) {
+		$users_to_cache = array();
+
+		// this usually makes only sense when we have a bunch of users
+		if ( empty( $users ) || is_wp_error( $users ) || count( $users ) < 3 ) {
+			return $users;
+		}
+
+		foreach( $users as $user ) {
+			if ( isset( $user->ID ) ) {
+				$users_to_cache[$user->ID] = 1;
+			}
+		}
+
+		if ( empty( $users_to_cache ) ) {
+			return $users;
+		}
+
+		update_meta_cache( 'user', array_keys( $users_to_cache ) );
+		unset( $users_to_cache );
+
+		return $users;
 	}
 
 	/**

--- a/lib/core/class-groups-user.php
+++ b/lib/core/class-groups-user.php
@@ -109,7 +109,7 @@ class Groups_User implements I_Capable {
 		if ( Groups_Utility::id( $user_id ) ) {
 			$this->user = get_user_by( "id", $user_id );
 		} else {
-			$this->user = new WP_User( 0 );
+			$this->user = new WP_User( $user_id );
 		}
 	}
 


### PR DESCRIPTION
Changes to prevent n+1 problem when loading group users. See this discussion in the WordPress support forum: https://wordpress.org/support/topic/getting-users-of-group-is-inefficient
