### PR TITLE
Pre 2.0.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 2.0.1 =
 * Fixed an issue with conflicting cache entries with legacy mode enabled.
+* Fixed access restriction capabilities were reset when reenabling legacy mode.
 
 = 2.0.0 =
 * Changed the access restriction model to group-based access restrictions.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 == Groups changelog.txt ==
 
+= 2.0.1 =
+* Fixed an issue with conflicting cache entries with legacy mode enabled.
+
 = 2.0.0 =
 * Changed the access restriction model to group-based access restrictions.
 * Provides an optional legacy mode that supports the previous capability-based access restrictions.

--- a/groups.php
+++ b/groups.php
@@ -2,7 +2,7 @@
 /**
  * groups.php
  *
- * Copyright (c) 2011-2016 "kento" Karim Rahimpur www.itthinx.com
+ * Copyright (c) 2011-2017 "kento" Karim Rahimpur www.itthinx.com
  *
  * This code is released under the GNU General Public License.
  * See COPYRIGHT.txt and LICENSE.txt.
@@ -21,7 +21,7 @@
  * Plugin Name: Groups
  * Plugin URI: http://www.itthinx.com/plugins/groups
  * Description: Groups provides group-based user membership management, group-based capabilities and content access control.
- * Version: 2.0.0
+ * Version: 2.0.1
  * Author: itthinx
  * Author URI: http://www.itthinx.com
  * Donate-Link: http://www.itthinx.com
@@ -32,7 +32,7 @@
 if ( !defined( 'ABSPATH' ) ) {
 	exit;
 }
-define( 'GROUPS_CORE_VERSION', '2.0.0' );
+define( 'GROUPS_CORE_VERSION', '2.0.1' );
 define( 'GROUPS_FILE', __FILE__ );
 if ( !defined( 'GROUPS_CORE_DIR' ) ) {
 	define( 'GROUPS_CORE_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );

--- a/legacy/access/class-groups-post-access-legacy.php
+++ b/legacy/access/class-groups-post-access-legacy.php
@@ -31,7 +31,7 @@ class Groups_Post_Access_Legacy {
 	const POSTMETA_PREFIX = 'groups-';
 
 	const CACHE_GROUP     = 'groups';
-	const CAN_READ_POST   = 'can_read_post';
+	const CAN_READ_POST   = 'legacy_can_read_post';
 
 	const READ_POST_CAPABILITY = 'groups_read_post';
 	const READ_POST_CAPABILITY_NAME = 'Read Post';

--- a/legacy/admin/groups-admin-options-legacy.php
+++ b/legacy/admin/groups-admin-options-legacy.php
@@ -25,8 +25,9 @@ if ( !defined( 'ABSPATH' ) ) {
 
 /**
  * Legacy options admin screen extension.
+ * @param $legacy_switched boolean whether legacy mode setting has been changed during submit
  */
-function groups_admin_options_legacy() {
+function groups_admin_options_legacy( $legacy_switched ) {
 
 	global $wpdb;
 
@@ -35,7 +36,7 @@ function groups_admin_options_legacy() {
 	//
 	// handle legacy options after form submission
 	//
-	if ( isset( $_POST['submit'] ) ) {
+	if ( isset( $_POST['submit'] ) && !$legacy_switched ) {
 		if ( wp_verify_nonce( $_POST[GROUPS_ADMIN_OPTIONS_NONCE], 'admin' ) ) {
 			$valid_read_caps = array( Groups_Post_Access_Legacy::READ_POST_CAPABILITY );
 			if ( !empty( $_POST[GROUPS_READ_POST_CAPABILITIES] ) ) {

--- a/lib/admin/groups-admin-options.php
+++ b/lib/admin/groups-admin-options.php
@@ -53,6 +53,8 @@ function groups_admin_options() {
 		GROUPS_RESTRICT_ACCESS    => __( 'Restrict Access', 'groups' )
 	);
 
+	$previous_legacy_enable =  Groups_Options::get_option( GROUPS_LEGACY_ENABLE, GROUPS_LEGACY_ENABLE_DEFAULT );
+
 	//
 	// handle options form submission
 	//
@@ -294,7 +296,7 @@ function groups_admin_options() {
 		'</p>';
 	if ( $groups_legacy_enable ) {
 		require_once GROUPS_LEGACY_LIB . '/admin/groups-admin-options-legacy.php';
-		do_action( 'groups_admin_options_legacy' );
+		do_action( 'groups_admin_options_legacy', $groups_legacy_enable !== $previous_legacy_enable );
 	}
 
 	echo

--- a/readme.txt
+++ b/readme.txt
@@ -192,6 +192,7 @@ See also the [Groups Documentation](http://docs.itthinx.com/document/groups/) pa
 
 = 2.0.1 =
 * Fixed an issue with conflicting cache entries with legacy mode enabled.
+* Fixed access restriction capabilities were reset when reenabling legacy mode.
 
 = 2.0.0 =
 * Changed the access restriction model to group-based access restrictions.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://www.itthinx.com/plugins/groups
 Tags: access, access control, capability, capabilities, content, download, downloads, file, file access, files, group, groups, member, members, membership, memberships, paypal, permission, permissions, subscription, subscriptions, woocommerce
 Requires at least: 4.0
 Tested up to: 4.7.2
-Stable tag: 2.0.0
+Stable tag: 2.0.1
 License: GPLv3
 
 Groups is an efficient and powerful solution, providing group-based user membership management, group-based capabilities and content access control.
@@ -190,6 +190,9 @@ See also the [Groups Documentation](http://docs.itthinx.com/document/groups/) pa
 
 == Changelog ==
 
+= 2.0.1 =
+* Fixed an issue with conflicting cache entries with legacy mode enabled.
+
 = 2.0.0 =
 * Changed the access restriction model to group-based access restrictions.
 * Provides an optional legacy mode that supports the previous capability-based access restrictions.
@@ -206,5 +209,5 @@ See also the [Groups Documentation](http://docs.itthinx.com/document/groups/) pa
 
 == Upgrade Notice ==
 
-= 2.0.0 =
-Groups 2.0.0 simplifies the way access restrictions are handled.
+= 2.0.1 =
+Groups 2.0.1 simplifies the way access restrictions are handled.


### PR DESCRIPTION
* Fixed an issue with conflicting cache entries with legacy mode enabled.
* Fixed access restriction capabilities were reset when reenabling legacy mode.