### PR TITLE
Allow requested table names to be filtered

### DIFF
--- a/lib/core/wp-init.php
+++ b/lib/core/wp-init.php
@@ -145,7 +145,21 @@ require_once GROUPS_EXTRA_LIB . '/class-groups-extra.php';
  */
 function _groups_get_tablename( $name ) {
 	global $wpdb;
-	return $wpdb->prefix . GROUPS_TP . $name;
+
+	// Construct the table name.
+	$table_name = $wpdb->prefix . GROUPS_TP . $name;
+
+	/**
+	 * Filter the database table to query.
+	 *
+	 * @since 2.7.2
+	 *
+	 * @param str $table_name The constructed table name.
+	 * @param str $name The requested short-form table name.
+	 * @param str $wpdb->prefix The current WordPress table prefix.
+	 * @return str $table_name The possibly-modified table name.
+	 */
+	return apply_filters( 'groups_get_tablename', $table_name, $name, $wpdb->prefix );
 }
 
 /**


### PR DESCRIPTION
Hi Karim,

A fresh PR as promised in #95, this time with added persuasion :-)

First off then, let me try flattery: my collaborators and I love the Groups plugin, so a big thank you for developing and maintaining it!

Secondly, let me say that this kind of filter is by no means unusual - many major WordPress plugins allow the requested table name(s) to be filtered. For example, here's [where BuddyPress does this](https://github.com/buddypress/BuddyPress/blob/b600e33688d35dc5e072f57242cf47128e434a76/src/bp-core/bp-core-functions.php#L78-L102). What this means is that the schema can be altered for different contexts by other plugins. [BP Multi Network](https://wordpress.org/plugins/bp-multi-network/) (FWIW written by Ron Rennick, the "godfather" of WordPress MU) enables multiple BuddyPress communities in WordPress Multi-Network installs. The [BuddyPress Multi Network](https://buddydev.com/plugins/buddypress-multi-network/) plugin, on the other hand, enables multiple BuddyPress communities in WordPress Multisite installs. My point is that different schemas can be implemented by different plugins to suit the context with one simple filter.

As it stands, the Groups plugin assumes that every sub-site in a multisite network requires its own capabilities management. It creates its standard set of Groups tables per site - which might be described as the reverse default schema that BuddyPress implements (i.e. one community per Multisite) - and enforces separation of groups per site. This is understandable and sensible as a default. But Multisite is a flexible beast and it is by no means a given that each sub-site is used as a "standalone". Many Multisite instances (leaving Multi-Network out of this for the time being) use sub-sites as useful "containers" for various purposes, for example [BP Group Blog](https://wordpress.org/plugins/bp-groupblog/) enables a "blog" for a BuddyPress group where the content may be pulled in to the main site without users being aware that there's a sub-site at all. It's in this kind of context that this PR fits.

So let me describe my own use case, which I don't see as particularly unusual. I have a Multisite install where certain sets of capabilities need to be identical across the entire network. This is because those capabilities are synced with [CiviCRM](https://civicrm.org/) and users need to retain those capabilities regardless of the sub-site they happen to interact with CiviCRM through. CiviCRM implements ACLs internally via its own groups but does not expose those to WordPress by default. Syncing capabilities, therefore, is taken care of via the [CiviCRM Groups Sync](https://develop.tadpole.cc/plugins/civicrm-groups-sync) plugin that I have developed - using Groups as the means by which the capabilities are propagated across the Multisite instance.

In my case I would rather not keep all sub-site Groups tables in sync with the ones on the main site. I could, of course, do that but it seems fragile and contravenes the DRY principle. The filter in this PR therefore gives the Groups plugin the same flexibility that's baked into BuddyPress because I can now restrict Groups to a single point of reference for the user capabilities I'm interested in, i.e. retaining just the tables on the main site:

```php
// Prevent Groups from creating and destroying per-site tables.
remove_action( 'wpmu_new_blog', 'Groups_Controller::wpmu_new_blog', 9, 2 );
remove_action( 'delete_blog', 'Groups_Controller::delete_blog', 10, 2 );

// Prevent Groups from removing users from groups when removed from a blog.
remove_action( 'remove_user_from_blog', 'Groups_User_Group::remove_user_from_blog', 10, 2 );

// Filter the referenced tables.
add_filter( 'groups_get_tablename', 'my_groups_database_name', 10, 3 );

/**
 * Filter the database tables to query.
 *
 * @param str $table_name The constructed table name.
 * @param str $name The requested table name.
 * @param str $prefix The WordPress table prefix.
 * @return str $table_name The modified table name.
 */
function my_groups_database_name( $table_name, $name, $prefix ) {

	global $wpdb;
	static $my_db_prefix = '';

	// Get the main site prefix if we haven't already done so.
	if ( empty( $my_db_prefix ) ) {
		$my_db_prefix = $wpdb->get_blog_prefix( get_main_site_id() );
	}

	// Construct the table name.
	$table_name = $my_db_prefix . GROUPS_TP . $name;

	// --<
	return $table_name;

}
```

The result (leaving caching and cache-busting aside) is that Groups operates as a "global" container for certain sets of capabilities whilst retaining all the UI loveliness that the Groups plugin provides for managing user capabilities in various locations in WordPress admin.

I am, of course, open to any suggestions you may have for implementing this functionality without the filter in this PR and look forward to your reply!

Cheers, Christian