### PR TITLE
Allow requested table prefix to be filtered

### DIFF
--- a/lib/core/wp-init.php
+++ b/lib/core/wp-init.php
@@ -145,7 +145,19 @@ require_once GROUPS_EXTRA_LIB . '/class-groups-extra.php';
  */
 function _groups_get_tablename( $name ) {
 	global $wpdb;
-	return $wpdb->prefix . GROUPS_TP . $name;
+
+	/**
+	 * Filters the prefix of the database table to query.
+	 *
+	 * @since 2.9.0
+	 *
+	 * @param str $wpdb->prefix The current WordPress table prefix.
+	 * @return str The possibly-modified table prefix.
+	 */
+	$prefix = apply_filters( 'groups_get_table_prefix', $wpdb->prefix );
+
+	// Return the constructed table name.
+	return $prefix . GROUPS_TP . $name;
 }
 
 /**


### PR DESCRIPTION
@proaktion Another fresh PR as promised in #103, taking into account your thoughts on the scope of the filter. For details and discussion, please refer to that PR. 

The reworked filter in this PR gives the Groups plugin the same flexibility as the filter in #103 but without the potential to alter the tables that Groups refers to. Indeed, this is what BuddyPress does (and what I should have suggested in the first place) so thanks for highlighting the problem.

With this filter, I can still restrict Groups to a single point of reference for the user capabilities I'm interested in, i.e. retaining just the tables on the main site:

```php
// Prevent Groups from creating and destroying per-site tables.
remove_action( 'wpmu_new_blog', 'Groups_Controller::wpmu_new_blog', 9, 2 );
remove_action( 'delete_blog', 'Groups_Controller::delete_blog', 10, 2 );

// Prevent Groups from removing users from groups when removed from a blog.
remove_action( 'remove_user_from_blog', 'Groups_User_Group::remove_user_from_blog', 10, 2 );

// Filter the prefix of the referenced tables.
add_filter( 'groups_get_table_prefix', 'my_groups_table_prefix', 10, 1 );

/**
 * Filter the table prefix.
 *
 * @param str $prefix The WordPress table prefix.
 * @return str $my_db_prefix The modified table prefix.
 */
function my_groups_table_prefix( $prefix ) {

	global $wpdb;
	static $my_db_prefix = '';

	// Overwrite with the main site prefix.
	if ( empty( $my_db_prefix ) ) {
		$my_db_prefix = $wpdb->get_blog_prefix( get_main_site_id() );
	}

	return $my_db_prefix;

}
```

The result is the same as #103 from a functional perspective but with a lighter touch.

Cheers, Christian