### PR TITLE
Cache and restore only capabilities from the group

### DIFF
--- a/lib/wp/class-groups-wordpress.php
+++ b/lib/wp/class-groups-wordpress.php
@@ -82,8 +82,10 @@ class Groups_WordPress {
 			$hash    = md5( json_encode( $caps ) . json_encode( $args ) );
 			$cached  = Groups_Cache::get( self::HAS_CAP . '_' . $user_id . '_' . $hash, self::CACHE_GROUP );
 
+			$groups_caps = array();
+
 			if ( $cached !== null ) {
-				$allcaps = $cached->value;
+				$groups_caps = $cached->value;
 				unset( $cached );
 			} else {
 				$groups_user = new Groups_User( $user_id );
@@ -93,11 +95,17 @@ class Groups_WordPress {
 				remove_filter( 'user_has_cap', array( __CLASS__, 'user_has_cap' ), 10 );
 				foreach( $caps as $cap ) {
 					if ( $groups_user->can( $cap ) ) {
-						$allcaps[$cap] = true;
+						$groups_caps[ $cap ] = true;
 					}
 				}
 				add_filter( 'user_has_cap', array( __CLASS__, 'user_has_cap' ), 10, 4 );
-				Groups_Cache::set( self::HAS_CAP . '_' . $user_id . '_' . $hash, $allcaps, self::CACHE_GROUP );
+				Groups_Cache::set( self::HAS_CAP . '_' . $user_id . '_' . $hash, $groups_caps, self::CACHE_GROUP );
+			}
+
+			foreach( $caps as $cap ) {
+				if ( isset( $groups_caps[ $cap ] ) ) {
+					$allcaps[ $cap ] = true;
+				}
 			}
 		}
 		return $allcaps;


### PR DESCRIPTION
This caches just the capabilities that were granted from the Group check instead of all capabilities that were passed in as args.

This prevents capabilities that were added in other filters from being cached and restored when it is testing the group capabilities.


The issue that we were seeing that started this change is WooCommerce also has a filter that adds capabilities here: https://github.com/woocommerce/woocommerce/blob/4.1.1/includes/wc-user-functions.php#L409

If the capability check was called twice in one request then the first time the function from the groups plugin would fire first and cache the options without the WooCommerce capability added then the WooCommerce filter would fire and add the proper capability.

But, because the `remove_fitler` / `add_filter` dance happened in the Groups plugin function the filter would then be added to the WordPress filters after the WooCommerce one.

So the second time it was called, the WooCommerce filter fired first and added the capability to the array, however the Groups one ran second and retrieved the array from the cache from the first run which didn't have the WooCommerce capability and returned that overriding the incoming capabilities.