### PR TITLE
Get all the children group ids of current user

### DIFF
--- a/lib/core/class-groups-utility.php
+++ b/lib/core/class-groups-utility.php
@@ -115,6 +115,43 @@ class Groups_Utility {
 		}
 		$output .= '</ul>';
 	}
+	
+	public static function get_below_group_ids_from_user( $user_id ) {
+		$groups_user = new Groups_User( $user_id );
+		$user_group_ids = $groups_user->group_ids;
+		$all_groups = array();
+
+		foreach ($user_group_ids as $group){
+			array_push($all_groups, $group);
+			$somegroups = self::getChildrenIds($group);
+			$all_groups = array_merge($all_groups, $somegroups);
+
+		}
+		return $all_groups;
+	}
+
+
+	public static function get_childs(&$output, $parent) {
+		global $wpdb;
+		$group_table = _groups_get_tablename( 'group' );
+		$all_groups = $wpdb->get_results( $wpdb->prepare("SELECT group_id FROM $group_table WHERE parent_id = %d",
+			Groups_Utility::id( $parent ) ));
+
+		foreach($all_groups as $group) {
+			$output[] = $group->group_id;
+			self::get_childs($output, $group->group_id );
+		}
+		return $output;
+	}
+
+	public static function getChildrenIds($parent) {
+		$output = array();
+		self::get_childs($output, $parent);
+		return $output;
+	}
+
+	
+	
 
 	/**
 	 * Compares the two object's names, used for groups and


### PR DESCRIPTION
I wanted to implement and share a functionnality that a lot of users asked on the wordpress comments : 

the possibility to retrieve all the children groups below a current group we are currently assigned to.
parent
child1
    grandchild1
     grandchild2
child2

if the user is only affected to the parent group, the function get_below_group_ids_from_user($user_id) will return the ids from all the descendants (child1, child2, grandchiild1, grandchild2)

maybe  we need to rename these functions, but it helped me a lot.