### PR TITLE
Check whether a valid group is returned before calling group_id prop

### DIFF
--- a/lib/core/class-groups-group.php
+++ b/lib/core/class-groups-group.php
@@ -196,11 +196,11 @@ class Groups_Group implements I_Capable {
 
 			if ( $capability_id !== null ) {
 				// check if the group itself can
-				$result = ( Groups_Group_Capability::read( $this->group->group_id, $capability_id ) !== false );
+				$result = is_object($this->group) ? ( Groups_Group_Capability::read( $this->group->group_id, $capability_id ) !== false ) : null;
 				if ( !$result ) {
 					// find all parent groups and include in the group's
 					// upward hierarchy to see if any of these can
-					$group_ids		   = array( $this->group->group_id );
+					$group_ids		   = is_object($this->group) ? array( $this->group->group_id ) : array();
 					$iterations		  = 0;
 					$old_group_ids_count = 0;
 					$all_groups = $wpdb->get_var( "SELECT COUNT(*) FROM $group_table" );


### PR DESCRIPTION
Warning squash in PHP 8.0 - make sure `$this->group` is an object and not a bool when calling properties `$this->group->group_id`