### PR TITLE
Fix for call to undefined function wp_get_current_user

### DIFF
--- a/lib/access/class-groups-post-access.php
+++ b/lib/access/class-groups-post-access.php
@@ -103,6 +103,7 @@ class Groups_Post_Access {
 	 * Sets up filters to restrict access.
 	 */
 	public static function init() {
+		require_once ABSPATH . 'wp-includes/pluggable.php';
 		// post access
 		add_filter( 'posts_where', array( __CLASS__, 'posts_where' ), 10, 2 );
 		add_filter( 'get_pages', array( __CLASS__, 'get_pages' ), 1 );


### PR DESCRIPTION
When using the wp cli to clear transients it seems pluggable is not loaded and triggers a fatal error Fatal error: Uncaught Error: Call to undefined function wp_get_current_user()

Making sure pluggable is included solves undefined function issue

```
[staging] run /home/customer/bin/wp transient delete --all --path="/home/customer/www/example.com/current/web" --url="example.com"
[staging] err Fatal error: Uncaught Error: Call to undefined function wp_get_current_user() in /home/customer/www/example.com/releases/586/web/wp-includes/capabilities.php:877
[staging] err Stack trace:
[staging] err #0 /home/customer/www/example.com/releases/586/web/wp-content/plugins/groups/lib/access/class-groups-post-access.php(264): current_user_can('groups_admin_gr...')
[staging] err #1 /home/customer/www/example.com/releases/586/web/wp-includes/class-wp-hook.php(324): Groups_Post_Access::posts_where(' AND wp_posts.p...', Object(WP_Query))
[staging] err #2 /home/customer/www/example.com/releases/586/web/wp-includes/plugin.php(256): WP_Hook->apply_filters(' AND wp_posts.p...', Array)
[staging] err #3 /home/customer/www/example.com/releases/586/web/wp-includes/class-wp-query.php(2717): apply_filters_ref_array('posts_where', Array)
[staging] err #4 /home/customer/www/example.com/releases/586/web/wp-includes/class-wp-query.php(3824): WP_Query->get_posts()
[staging] err #5 /home/customer/www/example.com/releases/586/web/wp-includes/post.php(2452): WP_Query->query(Array)
[staging] err #6 /home/customer/www/example.com/releases/586/web/wp-content/plugins/advanced-custom-fields/includes/class-acf-internal-post-type.php(399): get_posts(Array)
[staging] err #7 /home/customer/www/example.com/releases/586/web/wp-content/plugins/advanced-custom-fields/includes/class-acf-internal-post-type.php(357): ACF_Internal_Post_Type->get_raw_posts()
[staging] err #8 /home/customer/www/example.com/releases/586/web/wp-content/plugins/advanced-custom-fields/includes/acf-internal-post-type-functions.php(153): ACF_Internal_Post_Type->get_posts(Array)
[staging] err #9 /home/customer/www/example.com/releases/586/web/wp-content/plugins/advanced-custom-fields/includes/acf-field-group-functions.php(118): acf_get_internal_post_type_posts('acf-field-group', Array)
[staging] err #10 /home/customer/www/example.com/releases/586/web/wp-content/plugins/woocommerce-products-filter/ext/acf_filter/index.php(62): acf_get_field_groups()
[staging] err #11 /home/customer/www/example.com/releases/586/web/wp-content/plugins/woocommerce-products-filter/ext/acf_filter/index.php(17): WOOF_ACF_FILTER->get_all_acf_meta()
[staging] err #12 /home/customer/www/example.com/releases/586/web/wp-content/plugins/woocommerce-products-filter/ext/acf_filter/index.php(233): WOOF_ACF_FILTER->__construct()
[staging] err #13 /home/customer/www/example.com/releases/586/web/wp-content/plugins/woocommerce-products-filter/index.php(3244): include_once('/home/customer/...')
[staging] err #14 /home/customer/www/example.com/releases/586/web/wp-content/plugins/woocommerce-products-filter/index.php(113): WOOF->init_extensions()
[staging] err #15 /home/customer/www/example.com/releases/586/web/wp-content/plugins/woocommerce-products-filter/index.php(3999): WOOF->__construct()
[staging] err #16 /home/customer/www/example.com/releases/586/web/wp-settings.php(473): include_once('/home/customer/...')
[staging] err #17 phar:///usr/local/bin/wp-cli.phar/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1349): require('/home/customer/...')
[staging] err #18 phar:///usr/local/bin/wp-cli.phar/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1267): WP_CLI\Runner->load_wordpress()
[staging] err #19 phar:///usr/local/bin/wp-cli.phar/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php(28): WP_CLI\Runner->start()
[staging] err #20 phar:///usr/local/bin/wp-cli.phar/vendor/wp-cli/wp-cli/php/bootstrap.php(83): WP_CLI\Bootstrap\LaunchRunner->process(Object(WP_CLI\Bootstrap\BootstrapState))
[staging] err #21 phar:///usr/local/bin/wp-cli.phar/vendor/wp-cli/wp-cli/php/wp-cli.php(32): WP_CLI\bootstrap()
[staging] err #22 phar:///usr/local/bin/wp-cli.phar/php/boot-phar.php(20): include('phar:///usr/loc...')
[staging] err #23 /usr/local/bin/wp-cli.phar(4): include('phar:///usr/loc...')
[staging] err #24 {main}
[staging] err thrown in /home/customer/www/example.com/releases/586/web/wp-includes/capabilities.php on line 877```